### PR TITLE
Switch to pycryptodome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ env:
 install:
   - "pip install tox tox-travis"
 script:
-  - "tox --force-dep pip$TEST_PIP_VERSION"
+  - "INSTALL_COMMAND_ARGS=${TEST_PIP_VERSION+--ignore-installed} tox --force-dep pip$TEST_PIP_VERSION"
 notifications:
   email: false

--- a/tests/test-requirements.txt
+++ b/tests/test-requirements.txt
@@ -1,3 +1,3 @@
 click==6.6
-pycrypto==2.6.1
+pycryptodome==3.6.6
 six==1.10.0

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ python =
     pypy: pypy
 
 [testenv]
+install_command = python -m pip install {env:INSTALL_COMMAND_ARGS:} {opts} {packages}
 commands = py.test --cov make_lambda_package {posargs}
 deps =
     pip

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 [tox]
-envlist = py27, py33, py34, py35, pypy, flake8, manifest
+envlist = py27, py33, py34, py35, py36, pypy, flake8, manifest
 
 [travis]
 python =
     2.7: py27
     3.3: py33
     3.4: py34
-    3.5: py35, flake8, manifest
+    3.5: py35
+    3.6: py36, flake8, manifest
     pypy: pypy
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,17 @@
 [tox]
-envlist=py27, py33, py34, py35, pypy, flake8, manifest
+envlist = py27, py33, py34, py35, pypy, flake8, manifest
 
-[tox:travis]
-2.7 = py27
-3.3 = py33
-3.4 = py34
-3.5 = py35, flake8, manifest
-pypy = pypy
+[travis]
+python =
+    2.7: py27
+    3.3: py33
+    3.4: py34
+    3.5: py35, flake8, manifest
+    pypy: pypy
 
 [testenv]
-commands=py.test --cov make_lambda_package {posargs}
-deps=
+commands = py.test --cov make_lambda_package {posargs}
+deps =
     pip
     pytest
     pytest-cov


### PR DESCRIPTION
See: https://nvd.nist.gov/vuln/detail/CVE-2018-6594
Although we don't actually use this to do anything in this repo (it's for testing compilation of extensions), it's good to be clear of any deps with a vulnerability.